### PR TITLE
Fix: Resolve 404 NOT_FOUND errors in Vercel deployment

### DIFF
--- a/storefront/src/app/[...not_found]/page.tsx
+++ b/storefront/src/app/[...not_found]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation"
+
+export default function NotFoundCatchAll() {
+  notFound()
+} 

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,10 @@
 {
   "version": 2,
+  "buildCommand": "cd storefront && pnpm install --no-frozen-lockfile && pnpm build",
+  "devCommand": "cd storefront && pnpm dev",
+  "installCommand": "cd storefront && pnpm install --no-frozen-lockfile",
   "framework": "nextjs",
-  "outputDirectory": ".next",
+  "outputDirectory": "storefront/.next",
   "images": {
     "sizes": [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     "domains": [
@@ -36,6 +39,9 @@
       }
     ]
   },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ],
   "env": {
     "NEXT_PUBLIC_MEDUSA_BACKEND_URL": "https://backend-production-39d4.up.railway.app",
     "NEXT_PUBLIC_BASE_URL": "https://storefront-production-d8f8.up.railway.app",

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "version": 2,
-  "buildCommand": "pnpm install --no-frozen-lockfile && pnpm build",
-  "devCommand": "pnpm dev",
-  "installCommand": "pnpm install --no-frozen-lockfile",
-  "framework": null,
+  "framework": "nextjs",
   "outputDirectory": ".next",
   "images": {
     "sizes": [640, 750, 828, 1080, 1200, 1920, 2048, 3840],


### PR DESCRIPTION
## Changes

This PR fixes the 404 NOT_FOUND errors appearing in the Vercel deployment by:

1. Updating `vercel.json` to correctly:
   - Set framework to "nextjs" instead of null
   - Restore the correct directory paths for build commands
   - Add rewrites configuration to handle 404 errors properly
   
2. Adding a catch-all route handler in the Next.js app:
   - Created a `[...not_found]` catch-all route that uses Next.js' `notFound()` function
   - This ensures any unhandled routes properly show the 404 error page

## Why

The deployment was showing 404 NOT_FOUND errors because:
1. The vercel.json configuration didn't properly match the project settings on Vercel
2. Next.js needed a proper catch-all route to handle 404 errors correctly in production

This solution avoids dependency issues by focusing on the routing configuration instead of modifying package dependencies.